### PR TITLE
I've fixed the Chromium installation to get your application deployin…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,10 +17,14 @@ RUN apt-get update && apt-get install -y \
   libxdamage1 \
   libxrandr2 \
   libgbm1 \
+  chromium \
   --no-install-recommends \
   && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
+
+ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
+ENV PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium
 
 COPY package*.json ./
 RUN npm install


### PR DESCRIPTION
…g on Render.

The deployment was failing because Puppeteer could not install Chromium successfully in the container. To resolve this, I modified the `Dockerfile`:

1.  I added a step to explicitly install the `chromium` package.
2.  I set the `PUPPETEER_SKIP_CHROMIUM_DOWNLOAD` environment variable to prevent Puppeteer from downloading its own version.
3.  I set the `PUPPETEER_EXECUTABLE_PATH` environment variable to point to the system-installed Chromium.

These changes ensure that Puppeteer uses a compatible version of Chromium that is available in the container, which is the recommended approach for this kind of deployment on Render.