### PR TITLE
Fix(network): Resolve DNS and timeout errors during navigation

### DIFF
--- a/shorten-links.js
+++ b/shorten-links.js
@@ -37,7 +37,11 @@ function checkSiteAvailable(url) {
 
     const browser = await puppeteer.launch({
       headless: true,
-      args: ["--no-sandbox", "--disable-setuid-sandbox"],
+      args: [
+        "--no-sandbox",
+        "--disable-setuid-sandbox",
+        "--dns-server=8.8.8.8",
+      ],
     });
 
     const page = await browser.newPage();
@@ -120,7 +124,10 @@ function checkSiteAvailable(url) {
         const shortLink = await page.$eval("input#link-result-url", (el) => el.value);
 
         const newTab = await browser.newPage();
-        await newTab.goto(shortLink, { waitUntil: "domcontentloaded" });
+        await newTab.goto(shortLink, {
+          waitUntil: "domcontentloaded",
+          timeout: 60000,
+        });
         await newTab.waitForTimeout(3000);
         await newTab.close();
 


### PR DESCRIPTION
The application was failing to validate the shortened links in a new tab due to two network-related errors: `net::ERR_NAME_NOT_RESOLVED` and a subsequent `Runtime.callFunctionOn timed out`.

This commit fixes these issues by:
1. Forcing Chromium to use Google's public DNS server (`8.8.8.8`) by adding the `--dns-server` launch argument. This should prevent DNS resolution failures within the Render environment.
2. Increasing the page navigation timeout to 60 seconds. This makes the script more resilient to slow network responses and prevents it from timing out while waiting for the new tab to load.