### PR TITLE
Fix: Add explicit wait for button to prevent race condition

### DIFF
--- a/shorten-links.js
+++ b/shorten-links.js
@@ -94,6 +94,7 @@ function checkSiteAvailable(url) {
       }
 
       try {
+        await page.waitForSelector('#modal-open-new-link', { visible: true });
         await page.click("#modal-open-new-link");
         await page.waitForSelector("input#url", { visible: true });
         await page.evaluate(() => {


### PR DESCRIPTION
The script was failing with a "No element found for selector" error. This occurred because after navigating back to the main links page, the script would immediately try to click the "new link" button before it was necessarily visible or rendered by the page's JavaScript.

This commit fixes this race condition by adding an explicit `page.waitForSelector(...)` with the `{ visible: true }` option. This ensures the script will always wait for the button to be fully available before proceeding, making the loop much more robust.