### PR TITLE
Chore: Update default Docker command and improve logging

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,4 +30,4 @@ COPY package*.json ./
 RUN npm install
 COPY . .
 
-CMD ["npm", "start"]
+CMD ["npm", "run", "visit"]

--- a/visit-links.js
+++ b/visit-links.js
@@ -46,7 +46,7 @@ const INPUT_FILE = "cutt_links.txt";
         console.log(`  ... waiting 3 seconds.`);
         await new Promise(r => setTimeout(r, 3000));
 
-        console.log('  ✅ Success.');
+        console.log(`  ✅ Link viewed successfully: ${url}`);
 
       } catch (err) {
         console.error(`  ❌ Error visiting ${url}:`, err.message);


### PR DESCRIPTION
This commit introduces two final adjustments based on your feedback:

1.  The `CMD` in the `Dockerfile` has been changed from `npm start` to `npm run visit`. This makes the `visit-links.js` script the default entry point for the container, simplifying deployment.
2.  The success log message in `visit-links.js` has been made more descriptive to clearly indicate which URL has been processed.